### PR TITLE
Modify cuDNN function calls for compatibility with versions 5, 6, and (upcoming) 7

### DIFF
--- a/code/nvidia/conv_bench.cu
+++ b/code/nvidia/conv_bench.cu
@@ -267,8 +267,10 @@ public:
             return "FFT_TILING";
         else if (fwd_algo_ == CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD)
             return "WINOGRAD";
+#if CUDNN_MAJOR >= 6
         else if (fwd_algo_ == CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD_NONFUSED)
             return "WINOGRAD_NONFUSED";
+#endif
         else {
             std::stringstream ss;
             ss << "Illegal algorithm passed to get_fwd_algo_string. Algo: " << fwd_algo_ << std::endl;

--- a/code/nvidia/cudnn_helper.h
+++ b/code/nvidia/cudnn_helper.h
@@ -350,7 +350,11 @@ public:
         cudnnRNNDescriptor_t * desc = new cudnnRNNDescriptor_t;
 
         CHECK_CUDNN_ERROR(cudnnCreateRNNDescriptor(desc));
+#if CUDNN_MAJOR >= 7
+        CHECK_CUDNN_ERROR(cudnnSetRNNDescriptor_v5(*desc,
+#else
         CHECK_CUDNN_ERROR(cudnnSetRNNDescriptor(*desc,
+#endif
                                                 hidden_size,
                                                 num_layers,
                                                 dropout_desc,

--- a/code/nvidia/nccl_mpi_all_reduce.cu
+++ b/code/nvidia/nccl_mpi_all_reduce.cu
@@ -62,7 +62,7 @@ int main(int argc, char *argv[]) {
     }
 
     for (auto &t_size: sizes) {
-        auto data = fill({t_size*size}, rank);
+        auto data = fill<float>({t_size*size}, rank);
 
         cudaStreamSynchronize(stream);
         auto start = std::chrono::steady_clock::now();


### PR DESCRIPTION
Modify calls to cudnnSetRNNDescriptor to be compatible with deprecation protocol, allowing DeepBench to compile for cuDNN versions 5, 6, and 7. Modify conv_bench algorithm-to-string function so that it will compile with cuDNN v5. Fix template type omission that causes errors on some versions of gcc.