### PR TITLE
Make cudnn_helper.h compile independently.

### DIFF
--- a/code/nvidia/cudnn_helper.h
+++ b/code/nvidia/cudnn_helper.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <memory>
 #include <sstream>
 #include <vector>
 


### PR DESCRIPTION
Previously, it would depend on <memory> having already been #included,
in order to access std::shared_ptr.