### PR TITLE
Upgrade intel gemm conv tests

### DIFF
--- a/code/intel/convolution/mkl_conv/Makefile
+++ b/code/intel/convolution/mkl_conv/Makefile
@@ -30,10 +30,10 @@ ifeq ($(MKLLIB), mklml_intel)
     EXTRALIB = -L$(MKLROOT)/lib -lmklml_intel
 endif
 ifeq ($(MKLLIB), mkl_rt)
-    EXTRALIB = -L$(MKLROOT)/lib/intel64/ -lmkl_rt \
+    EXTRALIB = -L$(MKLROOT)/lib -lmkl_rt \
 			   -Wl,-rpath,$(MKLROOT)/lib/intel64
 endif
-EXTRALIB += -liomp5 -lpthread -lm -ldl
+EXTRALIB += -L$(MKLROOT)/lib -liomp5 -lpthread -lm -ldl
 endif
 
 ifeq ($(CONVLIB),MKLDNN)
@@ -43,7 +43,7 @@ ifeq ($(MKLDNNROOT),)
         to the install directory.)
 endif
 EXTRACXXFLAGS = -I$(MKLDNNROOT)/include -DUSE_MKLDNN
-EXTRALIB = -L$(MKLDNNROOT)/lib -lmkldnn -Wl,-rpath,$(MKLDNNROOT)/lib
+EXTRALIB = -L$(MKLDNNROOT)/lib -lmkldnn -lmklml_intel -Wl,-rpath,$(MKLDNNROOT)/lib
 endif
 
 ifeq ($(DEBUG), 1)
@@ -53,7 +53,7 @@ OPTFLAGS = -O3
 endif
 
 CXX      = icpc
-CXXFLAGS = -Wall -std=c++11 $(OPTFLAGS) $(EXTRACXXFLAGS) -fopenmp -I../../../kernels
+CXXFLAGS = -Wall -std=c++11 $(OPTFLAGS) $(EXTRACXXFLAGS) -fopenmp -I../../../kernelss
 LFLAGS   = -lrt
 OBJS     = std_conv_bench.o
 

--- a/code/intel/convolution/mkl_conv/Makefile
+++ b/code/intel/convolution/mkl_conv/Makefile
@@ -30,10 +30,10 @@ ifeq ($(MKLLIB), mklml_intel)
     EXTRALIB = -L$(MKLROOT)/lib -lmklml_intel
 endif
 ifeq ($(MKLLIB), mkl_rt)
-    EXTRALIB = -L$(MKLROOT)/lib -lmkl_rt \
+    EXTRALIB = -L$(MKLROOT)/lib/intel64/ -lmkl_rt \
 			   -Wl,-rpath,$(MKLROOT)/lib/intel64
 endif
-EXTRALIB += -L$(MKLROOT)/lib -liomp5 -lpthread -lm -ldl
+EXTRALIB += -L$(MKLROOT)/lib/intel64/ -liomp5 -lpthread -lm -ldl
 endif
 
 ifeq ($(CONVLIB),MKLDNN)

--- a/code/intel/gemm/Makefile
+++ b/code/intel/gemm/Makefile
@@ -15,11 +15,11 @@
 # ******************************************************************************
 
 CC       =  icc
-CFLAGS	 =  -O2 -Wall -I$(MKLROOT)/include -I../../kernels -qopenmp -std=c++11
+CFLAGS	 =  -O2 -Wall -I$(MKLROOT)/include -I../../kernels -fopenmp -std=c++11
 
-EXTRALIB = -Wl,--start-group $(MKLROOT)/lib/intel64/libmkl_intel_lp64.a $(MKLROOT)/lib/intel64/libmkl_intel_thread.a $(MKLROOT)/lib/intel64/libmkl_core.a -Wl,--end-group -liomp5 -lpthread -lm -ldl
+EXTRALIB = -Wl,--start-group $(MKLROOT)/lib/libmkl_intel_lp64.a $(MKLROOT)/lib/libmkl_intel_thread.a $(MKLROOT)/lib/libmkl_core.a -Wl,--end-group -L$(MKLROOT)/lib/ -liomp5 -lpthread -lm -ldl
 
-all : sbench sbench_pack
+all : sbench sbench_pack ibench_s8u8s32
 
 ibench_s8u8s32 : ibench_s8u8s32.o
 	$(CC) $(CFLAGS) $^  $(EXTRALIB)  -o $@ 

--- a/code/intel/gemm/Makefile
+++ b/code/intel/gemm/Makefile
@@ -17,7 +17,7 @@
 CC       =  icc
 CFLAGS	 =  -O2 -Wall -I$(MKLROOT)/include -I../../kernels -fopenmp -std=c++11
 
-EXTRALIB = -Wl,--start-group $(MKLROOT)/lib/libmkl_intel_lp64.a $(MKLROOT)/lib/libmkl_intel_thread.a $(MKLROOT)/lib/libmkl_core.a -Wl,--end-group -L$(MKLROOT)/lib/ -liomp5 -lpthread -lm -ldl
+EXTRALIB = -Wl,--start-group $(MKLROOT)/lib/intel64/libmkl_intel_lp64.a $(MKLROOT)/lib/intel64/libmkl_intel_thread.a $(MKLROOT)/lib/intel64/libmkl_core.a -Wl,--end-group -L$(MKLROOT)/lib/intel64/ -liomp5 -lpthread -lm -ldl
 
 all : sbench sbench_pack ibench_s8u8s32
 

--- a/code/intel/gemm/Makefile
+++ b/code/intel/gemm/Makefile
@@ -19,7 +19,12 @@ CFLAGS	 =  -O2 -Wall -I$(MKLROOT)/include -I../../kernels -fopenmp -std=c++11
 
 EXTRALIB = -Wl,--start-group $(MKLROOT)/lib/intel64/libmkl_intel_lp64.a $(MKLROOT)/lib/intel64/libmkl_intel_thread.a $(MKLROOT)/lib/intel64/libmkl_core.a -Wl,--end-group -L$(MKLROOT)/lib/intel64/ -liomp5 -lpthread -lm -ldl
 
-all : sbench sbench_pack ibench_s8u8s32
+OPENBLAS_PATH?=/usr/local/openblas
+
+OPENBLAS_FLAGS = -O2 -Wall -I$(OPENBLAS_PATH)/include -I../../kernels -fopenmp -std=c++11 -DUSE_OPENBLAS
+OPENBLAS_LIBS = -L$(OPENBLAS_PATH)/lib -DUSE_OPENBLAS -lpthread -lm -ldl -lopenblas
+
+all : sbench sbench_pack ibench_s8u8s32 sbench_oblas
 
 ibench_s8u8s32 : ibench_s8u8s32.o
 	$(CC) $(CFLAGS) $^  $(EXTRALIB)  -o $@ 
@@ -33,11 +38,17 @@ sbench_pack : sbench_pack.o
 sbench_pack.o : bench.cpp ../../kernels/gemm_problems.h
 	$(CC) $(CFLAGS) -DPACKED_API -c -o $@ $<
 
+sbench.o: bench.cpp ../../kernels/gemm_problems.h
+	$(CC) $(CFLAGS) -c -o $@ $<
+
 sbench : sbench.o
 	$(CC) $(CFLAGS) $^  $(EXTRALIB)  -o $@ 
 
-sbench.o : bench.cpp ../../kernels/gemm_problems.h
-	$(CC) $(CFLAGS) -c -o $@ $<
+sbench_oblas.o : bench.cpp ../../kernels/gemm_problems.h
+	$(CC) $(OPENBLAS_FLAGS) -c -o $@ $<
+
+sbench_oblas: sbench_oblas.o
+	$(CC) $(OPENBLAS_FLAGS) $^ $(OPENBLAS_LIBS) -o $@
 
 clean :
 	rm -f *.o sbench sbench_pack ibench_s8u8s32

--- a/code/intel/gemm/run_mkl_igemm_ia.sh
+++ b/code/intel/gemm/run_mkl_igemm_ia.sh
@@ -34,4 +34,4 @@ echo "------------------------"
 echo " GEMM_S8U8S32 - "
 echo "--------------"
 echo " "
-numactl -m 1 ./ibench_s8u8s32
+numactl -m 0 ./ibench_s8u8s32 0

--- a/code/intel/gemm/run_mkl_sgemm_ia.sh
+++ b/code/intel/gemm/run_mkl_sgemm_ia.sh
@@ -33,10 +33,10 @@ echo "------------------------"
 echo "  SGEMM - "
 echo "--------------"
 echo " "
-numactl -m 1 ./sbench
+numactl -m 0 ./sbench
 echo " "
 echo "------------------------"
 echo " Packed SGEMM - "
 echo "--------------"
 echo " "
-numactl -m 1 ./sbench_pack
+numactl -m 0 ./sbench_pack

--- a/code/intel/spmm/Makefile
+++ b/code/intel/spmm/Makefile
@@ -19,7 +19,7 @@ ifeq ($(MKLROOT),)
 endif
 
 EXTRACXXFLAGS = -I$(MKLROOT)/include
-EXTRALIB = -L$(MKLROOT)/lib/intel64/ -lmkl_rt \
+EXTRALIB = -L$(MKLROOT)/lib/ -lmkl_rt \
 		   -Wl,-rpath,$(MKLROOT)/lib/intel64 -liomp5 -lpthread -lm -ldl
 
 ifeq ($(DEBUG), 1)
@@ -28,7 +28,7 @@ else
 OPTFLAGS = -O3 -fopenmp
 endif
 
-CXX      = icpc
+CXX      = g++
 CXXFLAGS = -Wall -std=c++11 $(OPTFLAGS) $(EXTRACXXFLAGS) -I../../kernels
 LFLAGS   = -lrt
 OBJS     = spmm_bench.o

--- a/code/intel/spmm/Makefile
+++ b/code/intel/spmm/Makefile
@@ -19,7 +19,7 @@ ifeq ($(MKLROOT),)
 endif
 
 EXTRACXXFLAGS = -I$(MKLROOT)/include
-EXTRALIB = -L$(MKLROOT)/lib/ -lmkl_rt \
+EXTRALIB = -L$(MKLROOT)/lib/intel64/ -lmkl_rt \
 		   -Wl,-rpath,$(MKLROOT)/lib/intel64 -liomp5 -lpthread -lm -ldl
 
 ifeq ($(DEBUG), 1)
@@ -28,7 +28,7 @@ else
 OPTFLAGS = -O3 -fopenmp
 endif
 
-CXX      = g++
+CXX      = icpc
 CXXFLAGS = -Wall -std=c++11 $(OPTFLAGS) $(EXTRACXXFLAGS) -I../../kernels
 LFLAGS   = -lrt
 OBJS     = spmm_bench.o


### PR DESCRIPTION
This pull request upgrades the x86 xGEMM tests with a new library bindingto the OpenBLAS library to test and compare with the existing MKL library.  It also upgrades how the tests are instantiated with new command line arguments to specify individual matrices, or the built in tests, and # of threads.  

Output from GEMM and Convolution tests now output in a machine readable CSV format instead of just human readable text.

These changes are particularly useful for inserting Deepbench into automated testing infrastructures to get finer control and allow automatic parsing of test results.  This is the dual of the Arm test upgrades in pull request #102 .