### PR TITLE
Fix the parameter order of time_cnn in ARM convolution bench

### DIFF
--- a/code/arm/convolution.cpp
+++ b/code/arm/convolution.cpp
@@ -12,7 +12,7 @@
 
 using namespace arm_compute;
 
-int time_cnn(unsigned int w, unsigned int h, unsigned int n, unsigned int c, 
+int time_cnn(unsigned int w, unsigned int h, unsigned int c, unsigned int n,
              unsigned int k, unsigned int filter_w, int filter_h,
              unsigned int pad_w, unsigned int pad_h, 
              unsigned int wstride, unsigned int hstride,


### PR DESCRIPTION
Hi, I was looking at the code of convolution benchmark on ARM, and found the calling order and declaration order of parameters of `time_cnn` does not match. I believe the order of 'c' and 'n' should be exchanged.

Declaration:
```c
int time_cnn(unsigned int w, unsigned int h, unsigned int n, unsigned int c, 
             unsigned int k, unsigned int filter_w, int filter_h,
             unsigned int pad_w, unsigned int pad_h, 
             unsigned int wstride, unsigned int hstride,

```
Calling:
```c
auto time = time_cnn(w, h, c, n, k, filter_w, filter_h, pad_w, pad_h, wstride, hstride, num_repeats);
```